### PR TITLE
Improve type parsing

### DIFF
--- a/eindex/indexing.py
+++ b/eindex/indexing.py
@@ -124,7 +124,7 @@ def eindex(
     assert isinstance(pattern, str), "Last argument must be a string."
     
     # Convert everything to torch tensors (make sure that we remember whether it was originally a numpy array)
-    orig_type = "torch" if isinstance(arr, torch.Tensor) else "numpy"
+    orig_type = "numpy" if isinstance(arr, np.ndarray) else "torch"
     arr = torch.from_numpy(arr) if orig_type == "numpy" else arr
     index_tensor_list = [torch.from_numpy(i) if isinstance(i, np.ndarray) else i for i in index_tensor_list]
 

--- a/eindex/indexing.py
+++ b/eindex/indexing.py
@@ -123,9 +123,8 @@ def eindex(
     assert len(kwargs) == 0, f"Unexpected keyword arguments: {kwargs.keys()}"
     assert isinstance(pattern, str), "Last argument must be a string."
     
-    # Convert everything to torch tensors (make sure that we remember whether it was originally a numpy array)
-    orig_type = "numpy" if isinstance(arr, np.ndarray) else "torch"
-    arr = torch.from_numpy(arr) if orig_type == "numpy" else arr
+    # If numpy, convert to torch tensors
+    arr = torch.from_numpy(arr) if isinstance(arr, np.ndarray) else arr
     index_tensor_list = [torch.from_numpy(i) if isinstance(i, np.ndarray) else i for i in index_tensor_list]
 
     # Parse the pattern string into a list of dimension names (and a list of offsets, if they exist)

--- a/eindex/indexing.py
+++ b/eindex/indexing.py
@@ -124,7 +124,9 @@ def eindex(
     assert isinstance(pattern, str), "Last argument must be a string."
     
     # If numpy, convert to torch tensors
-    arr = torch.from_numpy(arr) if isinstance(arr, np.ndarray) else arr
+    # NOTE: remember the original type so we can convert back at the end
+    orig_is_numpy: bool = isinstance(arr, np.ndarray)
+    arr = torch.from_numpy(arr) if orig_is_numpy else arr
     index_tensor_list = [torch.from_numpy(i) if isinstance(i, np.ndarray) else i for i in index_tensor_list]
 
     # Parse the pattern string into a list of dimension names (and a list of offsets, if they exist)
@@ -308,7 +310,7 @@ def eindex(
             einops_operation = f"{' '.join(output_dims)} -> {einops_operation}"
             arr_indexed = einops.rearrange(arr_indexed, einops_operation)
 
-    if orig_type == "numpy":
+    if orig_is_numpy:
         arr_indexed = arr_indexed.numpy()
 
     return arr_indexed


### PR DESCRIPTION
The original code assumes that the input is exactly a `torch.Tensor`, otherwise thinks it is an `np.ndarray`. 

I've flipped the cases so that `np.ndarray` is the special case. This makes it work with NNsight. 

MWE: https://colab.research.google.com/drive/1G0JEiq_CWkR2t012wW9bnNSzbCT1BAbt?usp=sharing
